### PR TITLE
David/feature/leaderboard

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -360,3 +360,22 @@ header{
     margin:1rem;
   }
 }
+
+/* leaderboard styling currently on bottom to not effect line numbers for conflicts  Move into correct positioning once it is finished */
+.feev__leaderboard-page-wrap{
+  height:100%;
+  width:100%;
+  
+  display:flex;
+  justify-content:center;
+  align-items:center;
+}
+.feev__leaderboard-wrap{
+  margin:3rem;
+  width:100%;
+  height:100%;
+  display:flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items:center;
+}

--- a/client/src/components/side-nav.js
+++ b/client/src/components/side-nav.js
@@ -22,7 +22,7 @@ const SideNav = () => {
                         </div>
                         </div></li>
                     
-                    <li><Link to="/leaderboard"><i class="fa-solid fa-trophy"></i></Link> leaders</li>
+                    <li><Link to="/leaderboard"><i class="fa-solid fa-trophy"></i> leaders</Link></li>
                 </ul>
             
             </nav>

--- a/client/src/pages/leaderboard.js
+++ b/client/src/pages/leaderboard.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 const LeaderboardPage = () => {
     return (
         <div className="feev__home">
-
+           
         </div>
     )
 }

--- a/client/src/pages/leaderboard.js
+++ b/client/src/pages/leaderboard.js
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 
 const LeaderboardPage = () => {
     return (
-        <div className="feev__leaderboard">
+        <div className="feev__leader-board">
            
         </div>
     )

--- a/client/src/pages/leaderboard.js
+++ b/client/src/pages/leaderboard.js
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from 'react';
 
+
+// TODO work on front end styling of leaderboard page
+
+
 const LeaderboardPage = () => {
     return (
-        <div className="feev__home">
+        <div className="feev__leaderboard">
            
         </div>
     )

--- a/client/src/pages/leaderboard.js
+++ b/client/src/pages/leaderboard.js
@@ -6,8 +6,10 @@ import React, { useEffect, useState } from 'react';
 
 const LeaderboardPage = () => {
     return (
-        <div className="feev__leader-board">
-           
+        <div className="feev__leaderboard-page-wrap">
+           <div className="feev__leaderboard-wrap">
+            
+           </div>
         </div>
     )
 }


### PR DESCRIPTION
added to sidebar to allow the text "leaderboard" to be included in the link so the user can click either the icon or the text to get there, like the home link is
started styling of leaderboard page to fall in line with the style and size of other pages (will continue this over the weekend)
added leaderboard styling to temporarily bet at the bottom of css doc as to not interfere with anyone else's line numbers for easier merges